### PR TITLE
🐛 update the way to install typescript-eslint

### DIFF
--- a/articles/402774d76424e71ac906.md
+++ b/articles/402774d76424e71ac906.md
@@ -142,7 +142,7 @@ extends:
 npm i --save-dev @typescript-eslint/eslint-plugin @typescript-eslint/parser
 ```
 
-[インストールガイド](https://github.com/typescript-eslint/typescript-eslint/blob/master/docs/getting-started/linting/README.md)を見ながら次のように設定ファイルを書き換えます。
+[インストールガイド](https://github.com/typescript-eslint/typescript-eslint/blob/main/docs/linting/README.md)を見ながら次のように設定ファイルを書き換えます。
 
 ```yaml:.eslintrc.yml
 ---
@@ -152,7 +152,6 @@ plugins:
   - "@typescript-eslint"
 extends:
   - eslint:recommended
-  - plugin:@typescript-eslint/eslint-recommended
   - plugin:@typescript-eslint/recommended
 ```
 
@@ -174,7 +173,6 @@ plugins:
   - "@typescript-eslint"
 extends:
   - eslint:recommended
-  - plugin:@typescript-eslint/eslint-recommended
   - plugin:@typescript-eslint/recommended
   - prettier
 ```
@@ -187,7 +185,7 @@ extends:
 npm i --save-dev eslint-plugin-jest
 ```
 
-[`extends` への指定方法は @typescript-eslint のインストールガイドに書いてあります](https://github.com/typescript-eslint/typescript-eslint/blob/master/docs/getting-started/linting/README.md#plugins)ので要注意です。
+[`extends` への指定方法は @typescript-eslint のインストールガイドに書いてあります](https://github.com/typescript-eslint/typescript-eslint/blob/main/docs/linting/README.md#plugins)ので要注意です。
 
 ```yaml:.eslintrc.yml
 ---
@@ -198,7 +196,6 @@ plugins:
   - jest
 extends:
   - eslint:recommended
-  - plugin:@typescript-eslint/eslint-recommended
   - plugin:@typescript-eslint/recommended
   - plugin:jest/recommended
   - prettier
@@ -223,7 +220,6 @@ plugins:
   - jest
 extends:
   - eslint:recommended
-  - plugin:@typescript-eslint/eslint-recommended
   - plugin:@typescript-eslint/recommended
   - plugin:react/recommended
   - plugin:react-hooks/recommended


### PR DESCRIPTION
`@typescript-eslint` のインストールガイドが変わっているようでしたので[最新版](https://github.com/typescript-eslint/typescript-eslint/blob/main/docs/linting/README.md#plugins)に合わせてみました。
よろしくお願いいたします :bow: